### PR TITLE
use ghcr.io as build cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ on:
     - main
 
 env:
-  CONTAINER_IMAGE_NAME: ghcr.io/dalinjun/lease2fip-hcloud
+  IMAGE_NAME: lease2fip-hcloud
+  REGISTRY: ghcr.io/dalinjun
 
 jobs:
   package-platform-specific-container-image:
@@ -41,7 +42,7 @@ jobs:
     - id: metadata
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.CONTAINER_IMAGE_NAME }}
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - uses: docker/setup-buildx-action@v3
 
@@ -57,13 +58,13 @@ jobs:
       with:
         build-args: |
           GIT_COMMIT_HASH=${{ github.sha }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=registry,ref=${{ env.REGISTRY }}/build-workflow-cache:${{ env.PLATFORM_WITHOUT_SLASH }}
+        cache-to: type=registry,ref=${{ env.REGISTRY }}/build-workflow-cache:${{ env.PLATFORM_WITHOUT_SLASH }}
         labels: ${{ steps.metadata.outputs.labels }}
         outputs: type=image,push-by-digest=true,name-canonical=true,push=true
         platforms: ${{ env.PLATFORM }}
         provenance: false
-        tags: ${{ env.CONTAINER_IMAGE_NAME }}
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Export digest
       run: |
@@ -102,7 +103,7 @@ jobs:
     - id: metadata
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.CONTAINER_IMAGE_NAME }}
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -112,7 +113,7 @@ jobs:
     - name: Create manifest and push
       working-directory: ${{ runner.temp }}/digests
       run: |
-        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(printf '${{ env.CONTAINER_IMAGE_NAME }}@sha256:%s ' *)
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
     - name: Inspect image
-      run: docker buildx imagetools inspect ${{ env.CONTAINER_IMAGE_NAME }}:${{ steps.metadata.outputs.version }}
+      run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.metadata.outputs.version }}


### PR DESCRIPTION
This avoids an issue in the gha cache that
made one platform replace the cache of the other.
